### PR TITLE
Fixes crash in goroutine

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -50,11 +50,11 @@ func handleConnection(conn net.Conn) {
 	for {
 		ok := scanner.Scan()
 
-		handleMessage(scanner.Text(), conn)
-
 		if !ok {
 			break
 		}
+		
+		handleMessage(scanner.Text(), conn)
 	}
 
 	fmt.Println("Client at " + remoteAddr + " disconnected.")


### PR DESCRIPTION
Checking if the message is ok before handling it won't make the server crash if a client disconects without writing `/quit`